### PR TITLE
Enhance Makefile and add new tests for utilities package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt init upgrade install test run clean gamut lint
+.PHONY: help fmt lint lint-fix init upgrade install test test-coverage run clean gamut
 
 # Default target
 .DEFAULT_GOAL := help
@@ -33,6 +33,9 @@ install: ## Install Go Go Gadget
 test: ## Run tests
 	go test -v ./...
 
+test-coverage: ## Run tests with coverage
+	go test -coverprofile=coverage.out ./...
+
 run: ## Run Go Go Gadget
 	go run main.go
 
@@ -46,4 +49,5 @@ gamut: ## Run the Gamut
 	$(MAKE) lint
 	$(MAKE) run
 	$(MAKE) test
+	$(MAKE) test-coverage
 	$(MAKE) install

--- a/pkg/utilities/utilities_test.go
+++ b/pkg/utilities/utilities_test.go
@@ -1,7 +1,6 @@
 package utilities
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -96,7 +95,7 @@ module "my_module" {
 }
 
 func TestListTFResources(t *testing.T) {
-	content := fmt.Sprintf("resource \"aws_instance\" \"web\" {\n")
+	content := "resource \"aws_instance\" \"web\" {\n"
 	tmp := filepath.Join(t.TempDir(), "main.tf")
 	if err := os.WriteFile(tmp, []byte(content), 0600); err != nil {
 		t.Fatalf("failed to write temp file: %v", err)

--- a/pkg/utilities/utilities_test.go
+++ b/pkg/utilities/utilities_test.go
@@ -1,6 +1,9 @@
 package utilities
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -37,6 +40,68 @@ func TestUtilities(t *testing.T) {
 	if igr2 {
 		t.Errorf("IsGitRepo did not return false for a non-git directory.")
 	}
+}
+
+func TestFileDirExistsNonExistent(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	exists, err := FileDirExists(missing)
+	if err != nil {
+		t.Errorf("FileDirExists returned unexpected error: %v", err)
+	}
+	if exists {
+		t.Errorf("FileDirExists returned true for a path that does not exist")
+	}
+}
+
+func TestRunCommandError(t *testing.T) {
+	result := RunCommand("/nonexistent/binary-xyz", []string{}, ".")
+	if result == "" {
+		t.Errorf("RunCommand should return a non-empty string on error")
+	}
+}
+
+func TestShowDateTimeDefault(t *testing.T) {
+	got := ShowDateTime("bogus", false)
+	if got == "" {
+		t.Errorf("ShowDateTime with unknown format returned empty string")
+	}
+}
+
+func TestGrepFileForTFResources(t *testing.T) {
+	content := `resource "aws_s3_bucket" "my_bucket" {
+module "my_module" {
+  source = "./modules/foo"
+}
+`
+	tmp := filepath.Join(t.TempDir(), "main.tf")
+	if err := os.WriteFile(tmp, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	got := GrepFileForTFResources(tmp)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 targets, got %d: %v", len(got), got)
+	}
+
+	cases := []string{
+		"--target=aws_s3_bucket.my_bucket",
+		"--target=module.my_module",
+	}
+	for i, want := range cases {
+		if !strings.Contains(got[i], want) {
+			t.Errorf("got[%d] = %q, want it to contain %q", i, got[i], want)
+		}
+	}
+}
+
+func TestListTFResources(t *testing.T) {
+	content := fmt.Sprintf("resource \"aws_instance\" \"web\" {\n")
+	tmp := filepath.Join(t.TempDir(), "main.tf")
+	if err := os.WriteFile(tmp, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+	ListTFResources([]string{tmp})
 }
 
 func TestRegexTest(t *testing.T) {


### PR DESCRIPTION
- Updated Makefile to include a new test-coverage target and integrated it into the gamut target.
- Added multiple tests in utilities_test.go for file existence checks, command execution errors, date formatting, and Terraform resource parsing.